### PR TITLE
Set DCs as NTP pool

### DIFF
--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -65,9 +65,11 @@ class domain_join (
     class { 'chrony':
       servers => $time_servers.reduce( {}) |$cumulate, $server| {
         $cumulate.merge( { "${server}" => ['iburst', 'prefer'] })
+        $cumulate
       },
       pools   => $currdomain.reduce( {}) |$cumulate, $server| {
         $cumulate.merge( { "${server}" => ['iburst'] })
+        $cumulate
       },
     }
   }

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -63,7 +63,12 @@ class domain_join (
 
   if $configure_chrony {
     class { 'chrony':
-      servers => $time_servers + [$currdomain],
+      servers => $time_servers.reduce( {}) |$cumulate, $server| {
+        $cumulate.merge( { "${server}" => ['iburst', 'prefer'] })
+      },
+      pools   => $currdomain.reduce( {}) |$cumulate, $server| {
+        $cumulate.merge( { "${server}" => ['iburst'] })
+      },
     }
   }
 

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -63,11 +63,11 @@ class domain_join (
 
   if $configure_chrony {
     class { 'chrony':
-      servers => $time_servers.reduce( {}) |$cumulate, $server| {
+      servers => $time_servers.reduce({}) |$cumulate, $server| {
         $tmp = merge($cumulate, { "${server}" => ['iburst', 'prefer'] })
         $tmp
       },
-      pools   => [$currdomain].reduce( {}) |$cumulate, $server| {
+      pools   => [$currdomain].reduce({}) |$cumulate, $server| {
         $tmp = merge($cumulate, { "${server}" => ['iburst'] })
         $tmp
       },

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -64,12 +64,12 @@ class domain_join (
   if $configure_chrony {
     class { 'chrony':
       servers => $time_servers.reduce( {}) |$cumulate, $server| {
-        $cumulate.merge( { "${server}" => ['iburst', 'prefer'] })
-        $cumulate
+        $tmp = merge($cumulate, { "${server}" => ['iburst', 'prefer'] })
+        $tmp
       },
       pools   => $currdomain.reduce( {}) |$cumulate, $server| {
-        $cumulate.merge( { "${server}" => ['iburst'] })
-        $cumulate
+        $tmp = merge($cumulate, { "${server}" => ['iburst'] })
+        $tmp
       },
     }
   }

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -67,7 +67,7 @@ class domain_join (
         $tmp = merge($cumulate, { "${server}" => ['iburst', 'prefer'] })
         $tmp
       },
-      pools   => $currdomain.reduce( {}) |$cumulate, $server| {
+      pools   => [$currdomain].reduce( {}) |$cumulate, $server| {
         $tmp = merge($cumulate, { "${server}" => ['iburst'] })
         $tmp
       },


### PR DESCRIPTION
Only the PDC will operate as a NTP server. Using the domain's dns record as a pool will allow chronyd to sync to whichever server is the NTP server