### PR TITLE
Add OIDC support to domain_join

### DIFF
--- a/.readme/footer.md
+++ b/.readme/footer.md
@@ -2,13 +2,13 @@
 ### Option 1:
 1. Clone the repo and use the modules  
 ```bash
-git clone https://github.com/JasonN3/puppet_modules.git
+git clone https://github.com/JasonN3/openvox_modules.git
 ```
 ### Option 2:
-1. Edit your Puppetfile so r10k will clone the repo:  
+1. Edit your Puppetfile so g10k will clone the repo:  
 ```
 mod 'github',
-  :git          => 'https://github.com/JasonN3/puppet_modules.git',
+  :git          => 'https://github.com/JasonN3/openvox_modules.git',
   :ref          => 'main',
   :install_path => 'git'
 ```

--- a/.readme/header.md
+++ b/.readme/header.md
@@ -1,5 +1,5 @@
-# Puppet Modules
+# OpenVox Modules
 
 ## Description
-This is a collection of Puppet modules that I commonly use that make management of various Linux systems easier.
+This is a collection of OpenVox modules that I commonly use that make management of various Linux systems easier.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Puppet Modules
+# OpenVox Modules
 
 ## Description
-This is a collection of Puppet modules that I commonly use that make management of various Linux systems easier.
+This is a collection of OpenVox modules that I commonly use that make management of various Linux systems easier.
 
 ---
 ## Modules list
@@ -16,13 +16,13 @@ Configires the node to use client/host certificates from Hashicorp Vault
 ### Option 1:
 1. Clone the repo and use the modules  
 ```bash
-git clone https://github.com/JasonN3/puppet_modules.git
+git clone https://github.com/JasonN3/openvox_modules.git
 ```
 ### Option 2:
-1. Edit your Puppetfile so r10k will clone the repo:  
+1. Edit your Puppetfile so g10k will clone the repo:  
 ```
 mod 'github',
-  :git          => 'https://github.com/JasonN3/puppet_modules.git',
+  :git          => 'https://github.com/JasonN3/openvox_modules.git',
   :ref          => 'main',
   :install_path => 'git'
 ```

--- a/domain_join/README.md
+++ b/domain_join/README.md
@@ -39,16 +39,20 @@ The following parameters are available in the `domain_join` class:
 * [`ad_trust`](#ad_trust)
 * [`update_os_info`](#update_os_info)
 * [`enable_smartcard_ssh`](#enable_smartcard_ssh)
+* [`oidc`](#oidc)
+* [`client_id`](#client_id)
+* [`client_secret`](#client_secret)
+* [`tenant_id`](#tenant_id)
 
 ##### <a name="username"></a>`username`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 The username used to domain join
 
 ##### <a name="sensitive_password"></a>`sensitive_password`
 
-Data type: `Sensitive[String]`
+Data type: `Optional[Sensitive[String]]`
 
 The password used to domain join
 
@@ -189,4 +193,30 @@ Data type: `Boolean`
 Enable smartcard authentication for SSH (Only seems to work on RHEL 8+)
 
 Default value: ``false``
+
+##### <a name="oidc"></a>`oidc`
+
+Data type: `Boolean`
+
+Use OIDC for authentication
+
+Default value: ``false``
+
+##### <a name="client_id"></a>`client_id`
+
+Data type: `Optional[String]`
+
+Client ID for OIDC authentication
+
+##### <a name="client_secret"></a>`client_secret`
+
+Data type: `Optional[String]`
+
+Optional secret for client
+
+##### <a name="tenant_id"></a>`tenant_id`
+
+Data type: `Optional[String]`
+
+Tenant ID for Entra ID authentication
 

--- a/domain_join/README.md
+++ b/domain_join/README.md
@@ -50,11 +50,15 @@ Data type: `Optional[String]`
 
 The username used to domain join
 
+Default value: ``undef``
+
 ##### <a name="sensitive_password"></a>`sensitive_password`
 
 Data type: `Optional[Sensitive[String]]`
 
 The password used to domain join
+
+Default value: ``undef``
 
 ##### <a name="global_admins"></a>`global_admins`
 
@@ -212,7 +216,7 @@ Default value: ``undef``
 
 ##### <a name="client_secret"></a>`client_secret`
 
-Data type: `Optional[String]`
+Data type: `Optional[Sensitive[String]]`
 
 Optional secret for client
 

--- a/domain_join/README.md
+++ b/domain_join/README.md
@@ -208,15 +208,21 @@ Data type: `Optional[String]`
 
 Client ID for OIDC authentication
 
+Default value: ``undef``
+
 ##### <a name="client_secret"></a>`client_secret`
 
 Data type: `Optional[String]`
 
 Optional secret for client
 
+Default value: ``undef``
+
 ##### <a name="tenant_id"></a>`tenant_id`
 
 Data type: `Optional[String]`
 
 Tenant ID for Entra ID authentication
+
+Default value: ``undef``
 

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -43,27 +43,52 @@
 #   Configures a service to update the OS information on the AD object on startup
 # @param enable_smartcard_ssh
 #   Enable smartcard authentication for SSH (Only seems to work on RHEL 8+)
+# @param oidc
+#   Use OIDC for authentication
+# @param client_id
+#   Client ID for OIDC authentication
+# @param client_secret
+#   Optional secret for client
+# @param tenant_id
+#   Tenant ID for Entra ID authentication
 class domain_join (
-  String                                                     $username,
-  Sensitive[String]                                          $sensitive_password,
-  String                                                     $global_admins,
-  String                                                     $global_ssh,
-  String                                                     $local_admins,
-  String                                                     $local_ssh,
-  Boolean                                                    $global_nopasswd      = false,
-  Boolean                                                    $local_nopasswd       = false,
-  String                                                     $sssd_home            = '/home',
-  Optional[String]                                           $override_domain      = undef,
-  Optional[String]                                           $domain_short         = undef,
-  Optional[String]                                           $dns_subdomain        = undef,
-  Boolean                                                    $dnsupdate            = true,
-  Optional[String]                                           $file_header          = undef,
-  Array                                                      $time_servers         = [],
-  Boolean                                                    $configure_chrony     = true,
-  Enum['disabled', 'enabled', 'required', 'lock-on-removal'] $smartcard            = 'disabled',
-  Optional[Array[String]]                                    $ad_trust             = undef,
-  Boolean                                                    $update_os_info       = false,
-  Boolean                                                    $enable_smartcard_ssh = false
+  Variant[{
+    String                                                     $username,
+    Sensitive[String]                                          $sensitive_password,
+    String                                                     $global_admins,
+    String                                                     $global_ssh,
+    String                                                     $local_admins,
+    String                                                     $local_ssh,
+    Boolean                                                    $global_nopasswd      = false,
+    Boolean                                                    $local_nopasswd       = false,
+    String                                                     $sssd_home            = '/home',
+    Optional[String]                                           $override_domain      = undef,
+    Optional[String]                                           $domain_short         = undef,
+    Optional[String]                                           $dns_subdomain        = undef,
+    Boolean                                                    $dnsupdate            = true,
+    Optional[String]                                           $file_header          = undef,
+    Array                                                      $time_servers         = [],
+    Boolean                                                    $configure_chrony     = true,
+    Enum['disabled', 'enabled', 'required', 'lock-on-removal'] $smartcard            = 'disabled',
+    Optional[Array[String]]                                    $ad_trust             = undef,
+    Boolean                                                    $update_os_info       = false,
+    Boolean                                                    $enable_smartcard_ssh = false,
+    Enum[false]                                                $oidc                 = false
+  },
+  {
+    Enum[true]       $oidc            = false,
+    String           $client_id,
+    Optional[String] $client_secret,
+    String           $tenant_id,
+    Optional[String] $override_domain  = undef,
+    Optional[String] $file_header      = undef,
+    Boolean          $configure_chrony = true,
+    Optional[String] $domain_short     = undef,
+    Array            $time_servers     = [],
+  }]
+  
+  
+
 ) {
   if $override_domain {
     $currdomain = $override_domain
@@ -83,7 +108,7 @@ class domain_join (
   } elsif $::file_header {
     $file_header_local = $::file_header
   } else {
-    $file_header_local = 'This file is being maintained by Puppet. Do not edit.'
+    $file_header_local = 'This file is being maintained by OpenVox. Do not edit.'
   }
   # lint:endignore
 
@@ -139,9 +164,17 @@ class domain_join (
   package { 'samba-common':
     ensure => installed,
   }
-  package { 'sssd':
-    ensure => installed,
+  if $oidc {
+    package { 'sssd':
+      name   => 'sssd-oidc',
+      ensure => installed,
+    }
+  } else {
+    package { 'sssd':
+      ensure => installed,
+    }
   }
+  
 
   if $ad_trust != undef {
     file { '/etc/sssd/pki':
@@ -167,41 +200,43 @@ class domain_join (
     }
   }
 
-  if($override_domain) {
-    # lint:ignore:140chars
-    $command = Sensitive("bash -c 'source /etc/os-release; echo -n \"${$sensitive_password.unwrap}\" | adcli join -H ${forced_fqdn} -D ${currdomain} -U \"${username}\" --stdin-password --os-name=\"\${NAME}\" --os-version=\"\${VERSION}\" --os-service-pack=\"\${VERSION_ID}\"'")
-    # lint:endignore
-  } else {
-    # lint:ignore:140chars
-    $command = Sensitive("bash -c 'source /etc/os-release; echo -n \"${$sensitive_password.unwrap}\" | adcli join -D ${currdomain} -U \"${username}\" --stdin-password --os-name=\"\${NAME}\" --os-version=\"\${VERSION}\" --os-service-pack=\"\${VERSION_ID}\"'")
-    # lint:endignore
-  }
+  unless $oidc {
+    if($override_domain) {
+      # lint:ignore:140chars
+      $command = Sensitive("bash -c 'source /etc/os-release; echo -n \"${$sensitive_password.unwrap}\" | adcli join -H ${forced_fqdn} -D ${currdomain} -U \"${username}\" --stdin-password --os-name=\"\${NAME}\" --os-version=\"\${VERSION}\" --os-service-pack=\"\${VERSION_ID}\"'")
+      # lint:endignore
+    } else {
+      # lint:ignore:140chars
+      $command = Sensitive("bash -c 'source /etc/os-release; echo -n \"${$sensitive_password.unwrap}\" | adcli join -D ${currdomain} -U \"${username}\" --stdin-password --os-name=\"\${NAME}\" --os-version=\"\${VERSION}\" --os-service-pack=\"\${VERSION_ID}\"'")
+      # lint:endignore
+    }
 
-  exec { 'Join':
-    command => $command,
-    path    => $facts['path'],
-    notify  => Service['sssd'],
-    creates => '/etc/krb5.keytab',
-    require => [
-      Package['adcli'],
-      Package['krb5-workstation'],
-      Package['samba-common'],
-      Package['samba-common-tools'],
-      Package['sssd'],
-      File['/etc/krb5.conf'],
-      File['/etc/sssd/sssd.conf'],
-    ],
-  }
+    exec { 'Join':
+      command => $command,
+      path    => $facts['path'],
+      notify  => Service['sssd'],
+      creates => '/etc/krb5.keytab',
+      require => [
+        Package['adcli'],
+        Package['krb5-workstation'],
+        Package['samba-common'],
+        Package['samba-common-tools'],
+        Package['sssd'],
+        File['/etc/krb5.conf'],
+        File['/etc/sssd/sssd.conf'],
+      ],
+    }
 
-  file { '/etc/systemd/system/update_adcli.service':
-    ensure  => file,
-    content => template('domain_join/update_adcli.service.erb'),
-    require => Exec['Join'],
-    notify  => Service['update_adcli'],
-  }
+    file { '/etc/systemd/system/update_adcli.service':
+      ensure  => file,
+      content => template('domain_join/update_adcli.service.erb'),
+      require => Exec['Join'],
+      notify  => Service['update_adcli'],
+    }
 
-  service { 'update_adcli':
-    enable => true,
+    service { 'update_adcli':
+      enable => true,
+    }
   }
 
   file { '/etc/krb5.conf':
@@ -210,10 +245,15 @@ class domain_join (
     notify  => Service['sssd'],
     require => Package['krb5-workstation'],
   }
+  if $oidc {
+    $sssd_src = 'domain_join/sssd.oidc.conf.erb'
+  } else {
+    $sssd_src = 'domain_join/sssd.conf.erb'
+  }
 
   file { '/etc/sssd/sssd.conf':
     ensure  => file,
-    content => template('domain_join/sssd.conf.erb'),
+    content => template($sssd_src),
     owner   => root,
     group   => root,
     mode    => '0400',
@@ -292,22 +332,26 @@ class domain_join (
     }
   }
 
-  case $smartcard {
-    'disabled': {
-      $enable_smartcard = ''
+  unless $oidc {
+    case $smartcard {
+      'disabled': {
+        $enable_smartcard = ''
+      }
+      'enabled': {
+        $enable_smartcard = 'with-smartcard'
+      }
+      'required': {
+        $enable_smartcard = 'with-smartcard-required'
+      }
+      'lock-on-removal': {
+        $enable_smartcard = 'with-smartcard-lock-on-removal'
+      }
+      default: {
+        err('How??')
+      }
     }
-    'enabled': {
-      $enable_smartcard = 'with-smartcard'
-    }
-    'required': {
-      $enable_smartcard = 'with-smartcard-required'
-    }
-    'lock-on-removal': {
-      $enable_smartcard = 'with-smartcard-lock-on-removal'
-    }
-    default: {
-      err('How??')
-    }
+  } else {
+    $enable_smartcard = ''
   }
 
   exec { 'Enable SSSD Authentication':

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -52,43 +52,30 @@
 # @param tenant_id
 #   Tenant ID for Entra ID authentication
 class domain_join (
-  Variant[{
-    String                                                     $username,
-    Sensitive[String]                                          $sensitive_password,
-    String                                                     $global_admins,
-    String                                                     $global_ssh,
-    String                                                     $local_admins,
-    String                                                     $local_ssh,
-    Boolean                                                    $global_nopasswd      = false,
-    Boolean                                                    $local_nopasswd       = false,
-    String                                                     $sssd_home            = '/home',
-    Optional[String]                                           $override_domain      = undef,
-    Optional[String]                                           $domain_short         = undef,
-    Optional[String]                                           $dns_subdomain        = undef,
-    Boolean                                                    $dnsupdate            = true,
-    Optional[String]                                           $file_header          = undef,
-    Array                                                      $time_servers         = [],
-    Boolean                                                    $configure_chrony     = true,
-    Enum['disabled', 'enabled', 'required', 'lock-on-removal'] $smartcard            = 'disabled',
-    Optional[Array[String]]                                    $ad_trust             = undef,
-    Boolean                                                    $update_os_info       = false,
-    Boolean                                                    $enable_smartcard_ssh = false,
-    Enum[false]                                                $oidc                 = false
-  },
-  {
-    Enum[true]       $oidc            = false,
-    String           $client_id,
-    Optional[String] $client_secret,
-    String           $tenant_id,
-    Optional[String] $override_domain  = undef,
-    Optional[String] $file_header      = undef,
-    Boolean          $configure_chrony = true,
-    Optional[String] $domain_short     = undef,
-    Array            $time_servers     = [],
-  }]
-  
-  
-
+  Optional[String]                                           $username,
+  Optional[Sensitive[String]]                                $sensitive_password,
+  String                                                     $global_admins,
+  String                                                     $global_ssh,
+  String                                                     $local_admins,
+  String                                                     $local_ssh,
+  Boolean                                                    $global_nopasswd      = false,
+  Boolean                                                    $local_nopasswd       = false,
+  String                                                     $sssd_home            = '/home',
+  Optional[String]                                           $override_domain      = undef,
+  Optional[String]                                           $domain_short         = undef,
+  Optional[String]                                           $dns_subdomain        = undef,
+  Boolean                                                    $dnsupdate            = true,
+  Optional[String]                                           $file_header          = undef,
+  Array                                                      $time_servers         = [],
+  Boolean                                                    $configure_chrony     = true,
+  Enum['disabled', 'enabled', 'required', 'lock-on-removal'] $smartcard            = 'disabled',
+  Optional[Array[String]]                                    $ad_trust             = undef,
+  Boolean                                                    $update_os_info       = false,
+  Boolean                                                    $enable_smartcard_ssh = false,
+  Boolean                                                    $oidc                 = false,
+  Optional[String]                                           $client_id,
+  Optional[String]                                           $client_secret,
+  Optional[String]                                           $tenant_id
 ) {
   if $override_domain {
     $currdomain = $override_domain

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -261,7 +261,7 @@ class domain_join (
     owner   => root,
     group   => root,
     mode    => '0400',
-    notify  => [ Service['sssd'], Exec['Enable SSSD Authentication'] ]
+    notify  => [ Service['sssd'], Exec['Enable SSSD Authentication'] ],
     require => Package['sssd'],
   }
 

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -77,6 +77,24 @@ class domain_join (
   Optional[Sensitive[String]]                                $client_secret        = undef,
   Optional[String]                                           $tenant_id            = undef
 ) {
+  if $oidc {
+    if !$client_id {
+      fail('domain_join: client_id must be provided when oidc is enabled')
+    }
+    if !$client_secret {
+      fail('domain_join: client_secret must be provided when oidc is enabled')
+    }
+    if !$tenant_id {
+      fail('domain_join: tenant_id must be provided when oidc is enabled')
+    }
+  } else {
+    if !username {
+      fail('domain_join: username must be provided when oidc is disbled')
+    }
+    if !sensitive_password {
+      fail('domain_join: sensitive_password must be provided when oidc is disbled')
+    }
+  }
   if $override_domain {
     $currdomain = $override_domain
     # This is only used if $override_domain is defined

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -168,8 +168,8 @@ class domain_join (
   }
   if $oidc {
     package { 'sssd':
-      name   => 'sssd-idp',
       ensure => installed,
+      name   => 'sssd-idp',
     }
   } else {
     package { 'sssd':
@@ -261,7 +261,7 @@ class domain_join (
     owner   => root,
     group   => root,
     mode    => '0400',
-    notify  => Service['sssd'],
+    notify  => [ Service['sssd'], Exec['Enable SSSD Authentication'] ]
     require => Package['sssd'],
   }
 
@@ -336,7 +336,9 @@ class domain_join (
     }
   }
 
-  unless $oidc {
+  if $oidc {
+    $enable_smartcard = ''
+  } else {
     case $smartcard {
       'disabled': {
         $enable_smartcard = ''
@@ -354,8 +356,6 @@ class domain_join (
         err('How??')
       }
     }
-  } else {
-    $enable_smartcard = ''
   }
 
   exec { 'Enable SSSD Authentication':

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -73,9 +73,9 @@ class domain_join (
   Boolean                                                    $update_os_info       = false,
   Boolean                                                    $enable_smartcard_ssh = false,
   Boolean                                                    $oidc                 = false,
-  Optional[String]                                           $client_id,
-  Optional[String]                                           $client_secret,
-  Optional[String]                                           $tenant_id
+  Optional[String]                                           $client_id            = undef,
+  Optional[String]                                           $client_secret        = undef,
+  Optional[String]                                           $tenant_id            = undef
 ) {
   if $override_domain {
     $currdomain = $override_domain
@@ -161,7 +161,6 @@ class domain_join (
       ensure => installed,
     }
   }
-  
 
   if $ad_trust != undef {
     file { '/etc/sssd/pki':

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -52,8 +52,8 @@
 # @param tenant_id
 #   Tenant ID for Entra ID authentication
 class domain_join (
-  Optional[String]                                           $username,
-  Optional[Sensitive[String]]                                $sensitive_password,
+  Optional[String]                                           $username             = undef,
+  Optional[Sensitive[String]]                                $sensitive_password   = undef,
   String                                                     $global_admins,
   String                                                     $global_ssh,
   String                                                     $local_admins,
@@ -74,7 +74,7 @@ class domain_join (
   Boolean                                                    $enable_smartcard_ssh = false,
   Boolean                                                    $oidc                 = false,
   Optional[String]                                           $client_id            = undef,
-  Optional[String]                                           $client_secret        = undef,
+  Optional[Sensitive[String]]                                $client_secret        = undef,
   Optional[String]                                           $tenant_id            = undef
 ) {
   if $override_domain {
@@ -153,7 +153,7 @@ class domain_join (
   }
   if $oidc {
     package { 'sssd':
-      name   => 'sssd-oidc',
+      name   => 'sssd-idp',
       ensure => installed,
     }
   } else {

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -81,18 +81,15 @@ class domain_join (
     if !$client_id {
       fail('domain_join: client_id must be provided when oidc is enabled')
     }
-    if !$client_secret {
-      fail('domain_join: client_secret must be provided when oidc is enabled')
-    }
     if !$tenant_id {
       fail('domain_join: tenant_id must be provided when oidc is enabled')
     }
   } else {
-    if !username {
-      fail('domain_join: username must be provided when oidc is disbled')
+    if !$username {
+      fail('domain_join: username must be provided when oidc is disabled')
     }
-    if !sensitive_password {
-      fail('domain_join: sensitive_password must be provided when oidc is disbled')
+    if !$sensitive_password {
+      fail('domain_join: sensitive_password must be provided when oidc is disabled')
     }
   }
   if $override_domain {

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -261,7 +261,10 @@ class domain_join (
     owner   => root,
     group   => root,
     mode    => '0400',
-    notify  => [ Service['sssd'], Exec['Enable SSSD Authentication'] ],
+    notify  => [
+      Service['sssd'],
+      Exec['Enable SSSD Authentication']
+    ],
     require => Package['sssd'],
   }
 

--- a/domain_join/manifests/init.pp
+++ b/domain_join/manifests/init.pp
@@ -218,7 +218,10 @@ class domain_join (
     exec { 'Join':
       command => $command,
       path    => $facts['path'],
-      notify  => Service['sssd'],
+      notify  => [
+        Service['sssd'],
+        Exec['Enable SSSD Authentication']
+      ],
       creates => '/etc/krb5.keytab',
       require => [
         Package['adcli'],
@@ -360,9 +363,6 @@ class domain_join (
 
   exec { 'Enable SSSD Authentication':
     command     => "${enablesssd} ${enable_smartcard}",
-    subscribe   => [
-      Exec['Join'],
-    ],
     path        => $facts['path'],
     refreshonly => true,
     require     => [

--- a/domain_join/spec/classes/domain_join_spec.rb
+++ b/domain_join/spec/classes/domain_join_spec.rb
@@ -15,7 +15,7 @@ describe 'domain_join' do
           'global_ssh' => 'EXAMPLE Linux SSH Users',
           'local_admins' => 'EXAMPLE %HOSTNAME% Admins',
           'local_ssh' => 'EXAMPLE %HOSTNAME% SSH Users',
-          'file_header' => 'Puppet managed'
+          'file_header' => 'OpenVox managed'
         }
       }
 

--- a/domain_join/templates/sssd.oidc.conf.erb
+++ b/domain_join/templates/sssd.oidc.conf.erb
@@ -1,0 +1,20 @@
+[sssd]
+services = nss, pam
+domains = <%= @currdomain.upcase %>
+
+[domain/<%= @currdomain.upcase %>]
+id_provider = idp
+idp_type = entra_id
+idp_client_id = <%= @client_id %>
+<% if @client_secret -%>
+idp_client_secret = <%= @client_secret %>
+<% end -%>
+idp_token_endpoint = https://login.microsoftonline.com/<%= @tenant_id %>/oauth2/v2.0/token
+idp_device_auth_endpoint = https://login.microsoftonline.com/<%= @tenant_id %>/oauth2/v2.0/devicecode
+idp_userinfo_endpoint = https://graph.microsoft.com/v1.0/me
+idp_id_scope = https%3A%2F%2Fgraph.microsoft.com%2F.default
+idp_auth_scope = openid profile email
+
+[nss]
+default_shell = /bin/bash
+fallback_homedir = /home/%u

--- a/domain_join/templates/sssd.oidc.conf.erb
+++ b/domain_join/templates/sssd.oidc.conf.erb
@@ -7,13 +7,14 @@ id_provider = idp
 idp_type = entra_id
 idp_client_id = <%= @client_id %>
 <% if @client_secret -%>
-idp_client_secret = <%= @client_secret %>
+idp_client_secret = <%= @client_secret.call('unwrap') %>
 <% end -%>
 idp_token_endpoint = https://login.microsoftonline.com/<%= @tenant_id %>/oauth2/v2.0/token
 idp_device_auth_endpoint = https://login.microsoftonline.com/<%= @tenant_id %>/oauth2/v2.0/devicecode
 idp_userinfo_endpoint = https://graph.microsoft.com/v1.0/me
 idp_id_scope = https%3A%2F%2Fgraph.microsoft.com%2F.default
 idp_auth_scope = openid profile email
+override_homedir = <%= @sssd_home -%>/%u
 
 [nss]
 default_shell = /bin/bash


### PR DESCRIPTION
This also updates some of the references to Puppet to OpenVox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect (OIDC) support with Microsoft Entra integration and conditional activation.
  * Introduced OIDC parameters (client ID, client secret, tenant) and made username/password optional to enable OIDC-only flows.
  * Added OIDC-specific SSSD configuration and adaptive install/join behavior when OIDC is enabled.

* **Documentation**
  * Rebranded to "OpenVox Modules" and updated README/header/footer, install instructions, repo URLs, and tooling references.

* **Tests**
  * Updated test expectations to reflect revised file header branding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->